### PR TITLE
provide system tests for system files

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Maven Integration Test
 
 on: [push]
 
@@ -14,4 +14,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B integration-test --file pom.xml

--- a/com.mimacom.ddd.dm.dem.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.dem.ui.tests/.classpath
@@ -2,17 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.dim.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.dim.ui.tests/.classpath
@@ -2,17 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.dmx.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.dmx.ui.tests/.classpath
@@ -2,17 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.dom.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.dom.ui.tests/.classpath
@@ -2,17 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.esm.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.esm.ui.tests/.classpath
@@ -2,17 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.sm.asm.ui.tests/.classpath
+++ b/com.mimacom.ddd.sm.asm.ui.tests/.classpath
@@ -2,17 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.sm.sim.ui.tests/.classpath
+++ b/com.mimacom.ddd.sm.sim.ui.tests/.classpath
@@ -2,17 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.sm.sus.ui.tests/.classpath
+++ b/com.mimacom.ddd.sm.sus.ui.tests/.classpath
@@ -2,17 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.system.tests/.classpath
+++ b/com.mimacom.ddd.system.tests/.classpath
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/com.mimacom.ddd.system.tests/.classpath
+++ b/com.mimacom.ddd.system.tests/.classpath
@@ -2,17 +2,12 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
+	<classpathentry kind="src" path="src">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="xtend-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.system.tests/.project
+++ b/com.mimacom.ddd.system.tests/.project
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.mimacom.ddd.system.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.mimacom.ddd.system.tests/.settings/org.eclipse.core.resources.prefs
+++ b/com.mimacom.ddd.system.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/com.mimacom.ddd.system.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/com.mimacom.ddd.system.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/com.mimacom.ddd.system.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/com.mimacom.ddd.system.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.mimacom.ddd.system.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/com.mimacom.ddd.system.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,6 @@
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/main/java.directory=xtend-gen
+BuilderConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
+outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
+outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/com.mimacom.ddd.system.tests/META-INF/MANIFEST.MF
+++ b/com.mimacom.ddd.system.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,20 @@
+Manifest-Version: 1.0
+Automatic-Module-Name: com.mimacom.ddd.system.tests
+Bundle-ManifestVersion: 2
+Bundle-Name: com.mimacom.ddd.system.tests
+Bundle-Vendor: mimacom ag
+Bundle-Version: 0.1.0.qualifier
+Bundle-SymbolicName: com.mimacom.ddd.system.tests; singleton:=true
+Bundle-ActivationPolicy: lazy
+Require-Bundle: com.mimacom.ddd.system,
+ com.mimacom.ddd.dm.base,
+ com.mimacom.ddd.dm.dmx,
+ com.mimacom.ddd.dm.dmx.tests,
+ com.mimacom.ddd.dm.dim,
+ com.mimacom.ddd.dm.dim.tests,
+ org.junit.jupiter.api;bundle-version="[5.0.0,6.0.0)",
+ org.eclipse.xtext.testing,
+ org.eclipse.xtext.xbase.testing,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.19.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: com.mimacom.ddd.system.tests;x-internal:=true

--- a/com.mimacom.ddd.system.tests/build.properties
+++ b/com.mimacom.ddd.system.tests/build.properties
@@ -1,0 +1,6 @@
+source.. = src/,\
+           src-gen/,\
+           xtend-gen/
+bin.includes = .,\
+               META-INF/
+bin.excludes = **/*.xtend

--- a/com.mimacom.ddd.system.tests/pom.xml
+++ b/com.mimacom.ddd.system.tests/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.mimacom.ddd</groupId>
+    <artifactId>com.mimacom.ddd.tycho.plugin.parent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../releng/com.mimacom.ddd.tycho.plugin.parent</relativePath>
+  </parent>
+
+  <artifactId>com.mimacom.ddd.system.tests</artifactId>
+  <packaging>eclipse-test-plugin</packaging>
+
+  <name>System Tests</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>gen-clean</id>
+            <phase>clean</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.xtend</groupId>
+        <artifactId>xtend-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <useUIHarness>false</useUIHarness>
+          <useUIThread>false</useUIThread>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/com.mimacom.ddd.system.tests/src/com/mimacom/ddd/system/tests/ParsingTest.xtend
+++ b/com.mimacom.ddd.system.tests/src/com/mimacom/ddd/system/tests/ParsingTest.xtend
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.^extension.ExtendWith
 
 import static org.junit.jupiter.api.Assertions.*
+import org.eclipse.emf.ecore.resource.Resource
 
 /**
  * Provides integration tests for system test files.
@@ -48,8 +49,9 @@ class ParsingTest {
 
   @Test
   def void parseBaseTypes() {
-    val content = dimParseHelper.parse(new URL(BASE_TYPES_URI.toString).openStream, BASE_TYPES_URI, null, resourceSet);
+    val content = dimParseHelper.parse(new URL(BASE_TYPES_URI.toString).openStream, BASE_TYPES_URI, null, resourceSet)
     assertNotNull(content)
+    assertNoErrorsOnResource(content.eResource)
   }
 
   @Test
@@ -57,8 +59,9 @@ class ParsingTest {
     val injector = new DmxInjectorProvider().injector
     val dmxParseHelper = injector.getInstance(ParseHelper)
     val content = dmxParseHelper.parse(new URL(SYSTEM_FUNCTIONS_URI.toString).openStream, SYSTEM_FUNCTIONS_URI, null,
-      resourceSet);
+      resourceSet)
     assertNotNull(content)
+    assertNoErrorsOnResource(content.eResource)
   }
 
   @Test
@@ -66,15 +69,17 @@ class ParsingTest {
     val injector = new DmxInjectorProvider().injector
     val dmxParseHelper = injector.getInstance(ParseHelper)
     val content = dmxParseHelper.parse(new URL(ASSIGNMENTS_URI.toString).openStream, ASSIGNMENTS_URI, null,
-      resourceSet);
+      resourceSet)
     assertNotNull(content)
+    assertNoErrorsOnResource(content.eResource)
   }
 
   @Test
   def void parseCustomTypes() {
     val content = dimParseHelper.parse(new URL(CUSTOM_TYPES_URI.toString).openStream, CUSTOM_TYPES_URI, null,
-      resourceSet);
+      resourceSet)
     assertNotNull(content)
+    assertNoErrorsOnResource(content.eResource)
   }
 
   @Test
@@ -82,8 +87,9 @@ class ParsingTest {
     val injector = new DmxInjectorProvider().injector
     val dmxParseHelper = injector.getInstance(ParseHelper)
     val content = dmxParseHelper.parse(new URL(MATH_FUNCTIONS_URI.toString).openStream, MATH_FUNCTIONS_URI, null,
-      resourceSet);
+      resourceSet)
     assertNotNull(content)
+    assertNoErrorsOnResource(content.eResource)
   }
 
   @Test
@@ -91,8 +97,16 @@ class ParsingTest {
     val injector = new DmxInjectorProvider().injector
     val dmxParseHelper = injector.getInstance(ParseHelper)
     val content = dmxParseHelper.parse(new URL(SYSTEM_TYPES_URI.toString).openStream, SYSTEM_TYPES_URI, null,
-      resourceSet);
+      resourceSet)
     assertNotNull(content)
+    assertNoErrorsOnResource(content.eResource)
+  }
+  
+  def void assertNoErrorsOnResource(Resource resource) {
+    val errors = resource.errors
+    if (!errors.empty) {
+      fail(String.format("%d errors, none expected: %s", errors.size, errors.map[it | it.message].join(", "))) 
+    }
   }
 
 }

--- a/com.mimacom.ddd.system.tests/src/com/mimacom/ddd/system/tests/ParsingTest.xtend
+++ b/com.mimacom.ddd.system.tests/src/com/mimacom/ddd/system/tests/ParsingTest.xtend
@@ -1,0 +1,98 @@
+package com.mimacom.ddd.system.tests
+
+import com.google.inject.Inject
+import com.google.inject.Provider
+import com.mimacom.ddd.dm.base.DDomain
+import com.mimacom.ddd.dm.dmx.tests.DmxInjectorProvider
+import java.net.URL
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.resource.XtextResourceSet
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.extensions.InjectionExtension
+import org.eclipse.xtext.testing.util.ParseHelper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.^extension.ExtendWith
+
+import static org.junit.jupiter.api.Assertions.*
+
+/**
+ * Provides integration tests for system test files.
+ */
+@ExtendWith(InjectionExtension)
+@InjectWith(SystemTestInjectorProvider)
+class ParsingTest {
+
+  static val PATH_PREFIX = "platform:/plugin/com.mimacom.ddd.system/src/com/mimacom/ddd/system/"
+
+  // files of a referenced OSGi bundle are loaded, hence test is executed as a plug-in test
+  static val ASSIGNMENTS_URI = URI.createURI('''«PATH_PREFIX»/Assignments.dmx''')
+  static val BASE_TYPES_URI = URI.createURI('''«PATH_PREFIX»/BaseTypes.dim''')
+  static val CUSTOM_TYPES_URI = URI.createURI('''«PATH_PREFIX»/CustomTypes.dim''')
+  static val MATH_FUNCTIONS_URI = URI.createURI('''«PATH_PREFIX»/MathFunctions.dmx''')
+  static val SYSTEM_FUNCTIONS_URI = URI.createURI('''«PATH_PREFIX»/SystemFunctions.dmx''')
+  static val SYSTEM_TYPES_URI = URI.createURI('''«PATH_PREFIX»/SystemTypes.dmx''')
+
+  // by default the parse helper injected is that of the "primary" injector returned by the injector provider
+  @Inject
+  ParseHelper<DDomain> dimParseHelper
+
+  var XtextResourceSet resourceSet = null
+
+  @Inject Provider<XtextResourceSet> resourceSetProvider
+
+  @BeforeEach
+  def void init() {
+    resourceSet = resourceSetProvider.get
+  }
+
+  @Test
+  def void parseBaseTypes() {
+    val content = dimParseHelper.parse(new URL(BASE_TYPES_URI.toString).openStream, BASE_TYPES_URI, null, resourceSet);
+    assertNotNull(content)
+  }
+
+  @Test
+  def void parseSystemFunctions() {
+    val injector = new DmxInjectorProvider().injector
+    val dmxParseHelper = injector.getInstance(ParseHelper)
+    val content = dmxParseHelper.parse(new URL(SYSTEM_FUNCTIONS_URI.toString).openStream, SYSTEM_FUNCTIONS_URI, null,
+      resourceSet);
+    assertNotNull(content)
+  }
+
+  @Test
+  def void parseAssignments() {
+    val injector = new DmxInjectorProvider().injector
+    val dmxParseHelper = injector.getInstance(ParseHelper)
+    val content = dmxParseHelper.parse(new URL(ASSIGNMENTS_URI.toString).openStream, ASSIGNMENTS_URI, null,
+      resourceSet);
+    assertNotNull(content)
+  }
+
+  @Test
+  def void parseCustomTypes() {
+    val content = dimParseHelper.parse(new URL(CUSTOM_TYPES_URI.toString).openStream, CUSTOM_TYPES_URI, null,
+      resourceSet);
+    assertNotNull(content)
+  }
+
+  @Test
+  def void parseMathFunctions() {
+    val injector = new DmxInjectorProvider().injector
+    val dmxParseHelper = injector.getInstance(ParseHelper)
+    val content = dmxParseHelper.parse(new URL(MATH_FUNCTIONS_URI.toString).openStream, MATH_FUNCTIONS_URI, null,
+      resourceSet);
+    assertNotNull(content)
+  }
+
+  @Test
+  def void parseSystemTypes() {
+    val injector = new DmxInjectorProvider().injector
+    val dmxParseHelper = injector.getInstance(ParseHelper)
+    val content = dmxParseHelper.parse(new URL(SYSTEM_TYPES_URI.toString).openStream, SYSTEM_TYPES_URI, null,
+      resourceSet);
+    assertNotNull(content)
+  }
+
+}

--- a/com.mimacom.ddd.system.tests/src/com/mimacom/ddd/system/tests/SystemTestInjectorProvider.xtend
+++ b/com.mimacom.ddd.system.tests/src/com/mimacom/ddd/system/tests/SystemTestInjectorProvider.xtend
@@ -1,0 +1,15 @@
+package com.mimacom.ddd.system.tests
+
+import com.mimacom.ddd.dm.dim.tests.DimInjectorProvider
+import com.mimacom.ddd.dm.dmx.tests.DmxInjectorProvider
+
+class SystemTestInjectorProvider extends DimInjectorProvider {
+
+  override protected internalCreateInjector() {
+    // do EMF registration and create injector for any referenced languages
+    new DmxInjectorProvider().injector
+    
+    super.internalCreateInjector()
+  }
+
+}

--- a/com.mimacom.ddd.system.tests/xtend-gen/com/mimacom/ddd/system/tests/ParsingTest.java
+++ b/com.mimacom.ddd.system.tests/xtend-gen/com/mimacom/ddd/system/tests/ParsingTest.java
@@ -7,8 +7,10 @@ import com.mimacom.ddd.dm.base.DDomain;
 import com.mimacom.ddd.dm.dmx.tests.DmxInjectorProvider;
 import com.mimacom.ddd.system.tests.SystemTestInjectorProvider;
 import java.net.URL;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.testing.InjectWith;
@@ -16,6 +18,9 @@ import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.eclipse.xtext.testing.util.ParseHelper;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function0;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,6 +120,7 @@ public class ParsingTest {
       String _string = ParsingTest.BASE_TYPES_URI.toString();
       final DDomain content = this.dimParseHelper.parse(new URL(_string).openStream(), ParsingTest.BASE_TYPES_URI, null, this.resourceSet);
       Assertions.assertNotNull(content);
+      this.assertNoErrorsOnResource(content.eResource());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -129,6 +135,7 @@ public class ParsingTest {
       final EObject content = dmxParseHelper.parse(new URL(_string).openStream(), ParsingTest.SYSTEM_FUNCTIONS_URI, null, 
         this.resourceSet);
       Assertions.assertNotNull(content);
+      this.assertNoErrorsOnResource(content.eResource());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -143,6 +150,7 @@ public class ParsingTest {
       final EObject content = dmxParseHelper.parse(new URL(_string).openStream(), ParsingTest.ASSIGNMENTS_URI, null, 
         this.resourceSet);
       Assertions.assertNotNull(content);
+      this.assertNoErrorsOnResource(content.eResource());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -155,6 +163,7 @@ public class ParsingTest {
       final DDomain content = this.dimParseHelper.parse(new URL(_string).openStream(), ParsingTest.CUSTOM_TYPES_URI, null, 
         this.resourceSet);
       Assertions.assertNotNull(content);
+      this.assertNoErrorsOnResource(content.eResource());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -169,6 +178,7 @@ public class ParsingTest {
       final EObject content = dmxParseHelper.parse(new URL(_string).openStream(), ParsingTest.MATH_FUNCTIONS_URI, null, 
         this.resourceSet);
       Assertions.assertNotNull(content);
+      this.assertNoErrorsOnResource(content.eResource());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -183,8 +193,21 @@ public class ParsingTest {
       final EObject content = dmxParseHelper.parse(new URL(_string).openStream(), ParsingTest.SYSTEM_TYPES_URI, null, 
         this.resourceSet);
       Assertions.assertNotNull(content);
+      this.assertNoErrorsOnResource(content.eResource());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  public void assertNoErrorsOnResource(final Resource resource) {
+    final EList<Resource.Diagnostic> errors = resource.getErrors();
+    boolean _isEmpty = errors.isEmpty();
+    boolean _not = (!_isEmpty);
+    if (_not) {
+      final Function1<Resource.Diagnostic, String> _function = (Resource.Diagnostic it) -> {
+        return it.getMessage();
+      };
+      Assertions.<Object>fail(String.format("%d errors, none expected: %s", Integer.valueOf(errors.size()), IterableExtensions.join(ListExtensions.<Resource.Diagnostic, String>map(errors, _function), ", ")));
     }
   }
 }

--- a/com.mimacom.ddd.system.tests/xtend-gen/com/mimacom/ddd/system/tests/ParsingTest.java
+++ b/com.mimacom.ddd.system.tests/xtend-gen/com/mimacom/ddd/system/tests/ParsingTest.java
@@ -1,0 +1,190 @@
+package com.mimacom.ddd.system.tests;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.mimacom.ddd.dm.base.DDomain;
+import com.mimacom.ddd.dm.dmx.tests.DmxInjectorProvider;
+import com.mimacom.ddd.system.tests.SystemTestInjectorProvider;
+import java.net.URL;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.resource.XtextResourceSet;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Functions.Function0;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Provides integration tests for system test files.
+ */
+@ExtendWith(InjectionExtension.class)
+@InjectWith(SystemTestInjectorProvider.class)
+@SuppressWarnings("all")
+public class ParsingTest {
+  private static final String PATH_PREFIX = "platform:/plugin/com.mimacom.ddd.system/src/com/mimacom/ddd/system/";
+  
+  private static final URI ASSIGNMENTS_URI = new Function0<URI>() {
+    @Override
+    public URI apply() {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append(ParsingTest.PATH_PREFIX);
+      _builder.append("/Assignments.dmx");
+      URI _createURI = URI.createURI(_builder.toString());
+      return _createURI;
+    }
+  }.apply();
+  
+  private static final URI BASE_TYPES_URI = new Function0<URI>() {
+    @Override
+    public URI apply() {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append(ParsingTest.PATH_PREFIX);
+      _builder.append("/BaseTypes.dim");
+      URI _createURI = URI.createURI(_builder.toString());
+      return _createURI;
+    }
+  }.apply();
+  
+  private static final URI CUSTOM_TYPES_URI = new Function0<URI>() {
+    @Override
+    public URI apply() {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append(ParsingTest.PATH_PREFIX);
+      _builder.append("/CustomTypes.dim");
+      URI _createURI = URI.createURI(_builder.toString());
+      return _createURI;
+    }
+  }.apply();
+  
+  private static final URI MATH_FUNCTIONS_URI = new Function0<URI>() {
+    @Override
+    public URI apply() {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append(ParsingTest.PATH_PREFIX);
+      _builder.append("/MathFunctions.dmx");
+      URI _createURI = URI.createURI(_builder.toString());
+      return _createURI;
+    }
+  }.apply();
+  
+  private static final URI SYSTEM_FUNCTIONS_URI = new Function0<URI>() {
+    @Override
+    public URI apply() {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append(ParsingTest.PATH_PREFIX);
+      _builder.append("/SystemFunctions.dmx");
+      URI _createURI = URI.createURI(_builder.toString());
+      return _createURI;
+    }
+  }.apply();
+  
+  private static final URI SYSTEM_TYPES_URI = new Function0<URI>() {
+    @Override
+    public URI apply() {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append(ParsingTest.PATH_PREFIX);
+      _builder.append("/SystemTypes.dmx");
+      URI _createURI = URI.createURI(_builder.toString());
+      return _createURI;
+    }
+  }.apply();
+  
+  @Inject
+  private ParseHelper<DDomain> dimParseHelper;
+  
+  private XtextResourceSet resourceSet = null;
+  
+  @Inject
+  private Provider<XtextResourceSet> resourceSetProvider;
+  
+  @BeforeEach
+  public void init() {
+    this.resourceSet = this.resourceSetProvider.get();
+  }
+  
+  @Test
+  public void parseBaseTypes() {
+    try {
+      String _string = ParsingTest.BASE_TYPES_URI.toString();
+      final DDomain content = this.dimParseHelper.parse(new URL(_string).openStream(), ParsingTest.BASE_TYPES_URI, null, this.resourceSet);
+      Assertions.assertNotNull(content);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void parseSystemFunctions() {
+    try {
+      final Injector injector = new DmxInjectorProvider().getInjector();
+      final ParseHelper dmxParseHelper = injector.<ParseHelper>getInstance(ParseHelper.class);
+      String _string = ParsingTest.SYSTEM_FUNCTIONS_URI.toString();
+      final EObject content = dmxParseHelper.parse(new URL(_string).openStream(), ParsingTest.SYSTEM_FUNCTIONS_URI, null, 
+        this.resourceSet);
+      Assertions.assertNotNull(content);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void parseAssignments() {
+    try {
+      final Injector injector = new DmxInjectorProvider().getInjector();
+      final ParseHelper dmxParseHelper = injector.<ParseHelper>getInstance(ParseHelper.class);
+      String _string = ParsingTest.ASSIGNMENTS_URI.toString();
+      final EObject content = dmxParseHelper.parse(new URL(_string).openStream(), ParsingTest.ASSIGNMENTS_URI, null, 
+        this.resourceSet);
+      Assertions.assertNotNull(content);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void parseCustomTypes() {
+    try {
+      String _string = ParsingTest.CUSTOM_TYPES_URI.toString();
+      final DDomain content = this.dimParseHelper.parse(new URL(_string).openStream(), ParsingTest.CUSTOM_TYPES_URI, null, 
+        this.resourceSet);
+      Assertions.assertNotNull(content);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void parseMathFunctions() {
+    try {
+      final Injector injector = new DmxInjectorProvider().getInjector();
+      final ParseHelper dmxParseHelper = injector.<ParseHelper>getInstance(ParseHelper.class);
+      String _string = ParsingTest.MATH_FUNCTIONS_URI.toString();
+      final EObject content = dmxParseHelper.parse(new URL(_string).openStream(), ParsingTest.MATH_FUNCTIONS_URI, null, 
+        this.resourceSet);
+      Assertions.assertNotNull(content);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void parseSystemTypes() {
+    try {
+      final Injector injector = new DmxInjectorProvider().getInjector();
+      final ParseHelper dmxParseHelper = injector.<ParseHelper>getInstance(ParseHelper.class);
+      String _string = ParsingTest.SYSTEM_TYPES_URI.toString();
+      final EObject content = dmxParseHelper.parse(new URL(_string).openStream(), ParsingTest.SYSTEM_TYPES_URI, null, 
+        this.resourceSet);
+      Assertions.assertNotNull(content);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+}

--- a/com.mimacom.ddd.system.tests/xtend-gen/com/mimacom/ddd/system/tests/SystemTestInjectorProvider.java
+++ b/com.mimacom.ddd.system.tests/xtend-gen/com/mimacom/ddd/system/tests/SystemTestInjectorProvider.java
@@ -1,0 +1,18 @@
+package com.mimacom.ddd.system.tests;
+
+import com.google.inject.Injector;
+import com.mimacom.ddd.dm.dim.tests.DimInjectorProvider;
+import com.mimacom.ddd.dm.dmx.tests.DmxInjectorProvider;
+
+@SuppressWarnings("all")
+public class SystemTestInjectorProvider extends DimInjectorProvider {
+  @Override
+  protected Injector internalCreateInjector() {
+    Injector _xblockexpression = null;
+    {
+      new DmxInjectorProvider().getInjector();
+      _xblockexpression = super.internalCreateInjector();
+    }
+    return _xblockexpression;
+  }
+}

--- a/com.mimacom.ddd.system/.classpath
+++ b/com.mimacom.ddd.system/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/com.mimacom.ddd.system/META-INF/MANIFEST.MF
+++ b/com.mimacom.ddd.system/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: mimacom
 Automatic-Module-Name: com.mimacom.ddd.system
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: com.mimacom.ddd.system

--- a/com.mimacom.ddd.system/src/com/mimacom/ddd/system/SystemFunctions.dmx
+++ b/com.mimacom.ddd.system/src/com/mimacom/ddd/system/SystemFunctions.dmx
@@ -16,7 +16,7 @@ filter length(arg : TEXT): NUMBER
 filter now(): TIMEPOINT
 filter toTimepoint(arg : TEXT): TIMEPOINT
 
-filter state(entity : COMPLEX) : STATE
+filter state(^entity : COMPLEX) : STATE
 filter transition(from : STATE, event : STATE_EVENT) : STATE
 
 filter delivered(arg : NOTIFICATION): BOOLEAN 	// always returns true

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     <module>com.mimacom.ddd.sm.sus.feature</module>
     <!-- system -->
     <module>com.mimacom.ddd.system</module>
+    <module>com.mimacom.ddd.system.tests</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Hi Oliver

Tests are now executed as part of the default build action. From the log, see these entries:
```
2019-11-27T10:54:25.8711317Z Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.394 s - in com.mimacom.ddd.system.tests.ParsingTest
2019-11-27T10:54:25.8712139Z parseSystemTypes  Time elapsed: 1.133 s
2019-11-27T10:54:25.8712547Z parseSystemFunctions  Time elapsed: 0.102 s
2019-11-27T10:54:25.8712665Z parseBaseTypes  Time elapsed: 0.059 s
2019-11-27T10:54:25.8712797Z parseMathFunctions  Time elapsed: 0.039 s
2019-11-27T10:54:25.8712941Z parseAssignments  Time elapsed: 0.04 s
2019-11-27T10:54:25.8713043Z parseCustomTypes  Time elapsed: 0.006 s
```
We'll have to find a way to publish test results, too. However, the new `com.mimacom.ddd.system.tests` project will cause the build to fail on any test failure (removed `<failIfNoTests>false</failIfNoTests>` property, which is still present in other modules).

The tests will currently just parse the DIM and DMX files, no assertions are made other than that parsing resulted in a non-null `EObject`.

Note that I did not move the system test files from the `com.mimacom.ddd.system` project. The tests, which are part of another bundle, will not read these files using `platform:/plugin` resource URLs. As a consequence, tests will have to be executed as Eclipse plug-in tests (or Maven integration tests).