### PR TITLE
add system bundle to base feature

### DIFF
--- a/com.mimacom.ddd.dm.base.feature/feature.xml
+++ b/com.mimacom.ddd.dm.base.feature/feature.xml
@@ -4,10 +4,19 @@
       label="Domain Model Base Feature"
       version="0.1.0.qualifier"
       provider-name="mimacom ag">
+
    <plugin
          id="com.mimacom.ddd.dm.base"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
+   <plugin
+         id="com.mimacom.ddd.system"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
Hi Oliver
This change adds the `com.mimacom.ddd.system` bundle to the "Domain Model Base Feature". As a result, the system bundle should be part of the product built by Tycho.