### PR TITLE
revert changes to new eclipse update site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ From the command line in the repository root directory, execute the following co
 **Troubleshooting**
 * possibly there is a limitation with the `xtend-maven-plugin`, see [this issue](https://github.com/eclipse/xtext-xtend/issues/576)
 * if Maven fails to build, try deleting the local repository, or use the `-Dmaven.repo.local` flag to specify a different repository
+* if the Maven build fails for mysterious reasons, check if there are any programs running which might have an impact on the build; for instance Visual Studio Code or Eclipse may notice when files on disk have changed and as a consequence perform an action that has an impact on the build
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ From the command line in the repository root directory, execute the following co
 
 ### Eclipse IDE setup
 Import the `com.mimacom.ddd.target` project from the `releng` folder into the workspace and set the target platform to the file `releng/com.mimacom.ddd.target/com.mimacom.ddd.target-latest.target`.
+
+### Related links
+* https://www.nikostotz.de/blog/combine-xcore-xtend-ecore-and-maven/

--- a/com.mimacom.ddd.dm.base/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/com.mimacom.ddd.dm.base/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -4,4 +4,6 @@ BuilderConfiguration.is_project_specific=true
 eclipse.preferences.version=1
 outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
 outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
+outlet.DEFAULT_OUTPUT.sourceFolder.emf-gen.directory=xtend-gen
+outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.directory=xtend-gen
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/com.mimacom.ddd.dm.base/META-INF/MANIFEST.MF
+++ b/com.mimacom.ddd.dm.base/META-INF/MANIFEST.MF
@@ -24,5 +24,5 @@ Require-Bundle: org.eclipse.emf.mwe2.lib;resolution:=optional,
  org.apache.log4j,
  org.eclipse.equinox.common;bundle-version="3.5.0",
  org.apache.commons.logging,
- org.eclipse.xtend.lib;bundle-version="2.19.0"
+ org.eclipse.xtend.lib
 Bundle-ActivationPolicy: lazy

--- a/com.mimacom.ddd.dm.base/pom.xml
+++ b/com.mimacom.ddd.dm.base/pom.xml
@@ -47,30 +47,11 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.xtext</groupId>
-            <artifactId>org.eclipse.xtext.common.types</artifactId>
-            <version>${xtext.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.xtext</groupId>
-            <artifactId>org.eclipse.xtext.xtext.generator</artifactId>
-            <version>${xtext.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.xtext</groupId>
-            <artifactId>org.eclipse.xtext.xbase</artifactId>
-            <version>${xtext.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.xtext</groupId>
-            <artifactId>xtext-antlr-generator</artifactId>
-            <version>[2.1.1, 3)</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
         </dependencies>
       </plugin>
+
       <plugin>
         <groupId>org.eclipse.xtend</groupId>
         <artifactId>xtend-maven-plugin</artifactId>
@@ -82,7 +63,7 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.base/emf-gen/</directory>
+              <directory>${project.basedir}/emf-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.dm.dem.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.dem.ui.tests/.classpath
@@ -2,7 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src-gen">
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.dem/pom.xml
+++ b/com.mimacom.ddd.dm.dem/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dem/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dem.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dem.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dem.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dem.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.dm.dim.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.dim.ui.tests/.classpath
@@ -2,7 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src-gen">
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.dim/pom.xml
+++ b/com.mimacom.ddd.dm.dim/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dim/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dim.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dim.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dim.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dim.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.dm.dmx.ide/META-INF/MANIFEST.MF
+++ b/com.mimacom.ddd.dm.dmx.ide/META-INF/MANIFEST.MF
@@ -9,7 +9,11 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: com.mimacom.ddd.dm.dmx,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
+ org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ com.google.guava,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtend.lib.macro
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.mimacom.ddd.dm.dmx.ide,
  com.mimacom.ddd.dm.dmx.ide.contentassist.antlr,

--- a/com.mimacom.ddd.dm.dmx.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.dmx.ui.tests/.classpath
@@ -2,7 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src-gen">
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.dmx/pom.xml
+++ b/com.mimacom.ddd.dm.dmx/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dmx/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dmx.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dmx.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dmx.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dmx.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.dm.dom.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.dom.ui.tests/.classpath
@@ -2,7 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src-gen">
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.dom/pom.xml
+++ b/com.mimacom.ddd.dm.dom/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dom/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dom.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dom.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dom.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.dom.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.dm.esm.ui.tests/.classpath
+++ b/com.mimacom.ddd.dm.esm.ui.tests/.classpath
@@ -2,7 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src-gen">
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.dm.esm/pom.xml
+++ b/com.mimacom.ddd.dm.esm/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.esm/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.esm.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.esm.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.esm.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.dm.esm.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.pub.proto.tests/.classpath
+++ b/com.mimacom.ddd.pub.proto.tests/.classpath
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="test-bin" path="src">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="test-bin" path="src-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="test-bin" path="xtend-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+  <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+  <classpathentry kind="src" path="src/"/>
+  <classpathentry kind="src" path="src-gen/"/>
+  <classpathentry kind="src" path="emf-gen/"/>
+  <classpathentry kind="src" path="xtend-gen/"/>
+  <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.mimacom.ddd.pub.proto.ui.tests/.classpath
+++ b/com.mimacom.ddd.pub.proto.ui.tests/.classpath
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="test-bin" path="src-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+  <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+  <classpathentry kind="src" path="src-gen/"/>
+  <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.mimacom.ddd.pub.proto/pom.xml
+++ b/com.mimacom.ddd.pub.proto/pom.xml
@@ -127,7 +127,7 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.pub.proto/emf-gen/</directory>
+              <directory>${project.basedir}/emf-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.pub.proto/pom.xml
+++ b/com.mimacom.ddd.pub.proto/pom.xml
@@ -20,9 +20,78 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>xtend-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.4.0</version>
+        <executions>
+          <execution>
+            <id>mwe2Launcher</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
+          <arguments>
+            <argument>/${project.basedir}/src/com/mimacom/ddd/pub/proto/GeneratePubProto.mwe2</argument>
+            <argument>-p</argument>
+            <argument>rootPath=/${project.basedir}/..</argument>
+          </arguments>
+          <classpathScope>compile</classpathScope>
+          <includePluginDependencies>true</includePluginDependencies>
+          <cleanupDaemonThreads>false</cleanupDaemonThreads><!-- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=475098#c3 -->
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
+            <version>${emf-mwe2-launch.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext.common.types</artifactId>
+            <version>${xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext.xtext.generator</artifactId>
+            <version>${xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext.xbase</artifactId>
+            <version>${xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>xtext-antlr-generator</artifactId>
+            <version>[2.1.1, 3)</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext.ecore</artifactId>
+            <version>${xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext.ecore</artifactId>
+            <version>${xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xcore</artifactId>
+            <version>${ecore-xcore.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xcore.lib</artifactId>
+            <version>1.4.0</version>
+          </dependency>
+        </dependencies>
       </plugin>
+
       <plugin>
         <groupId>org.eclipse.xtext</groupId>
         <artifactId>xtext-maven-plugin</artifactId>
@@ -121,22 +190,54 @@
           </dependency>
         </dependencies>
       </plugin>
+      
+      <plugin>
+        <groupId>org.eclipse.xtend</groupId>
+        <artifactId>xtend-maven-plugin</artifactId>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${project.basedir}/emf-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
+            </fileset>
+            <fileset>
+              <directory>${project.basedir}/src-gen/</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+            </fileset>
+            <fileset>
+              <directory>${project.basedir}/src-gen/</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+            </fileset>
+            <fileset>
+              <directory>${project.basedir}/src-gen/</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+            </fileset>
+            <fileset>
+              <directory>${project.basedir}/src-gen/</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+            </fileset>
+            <fileset>
+              <directory>${basedir}/model/generated/</directory>
             </fileset>
           </filesets>
         </configuration>
       </plugin>
     </plugins>
-
     <pluginManagement>
       <plugins>
         <plugin>

--- a/com.mimacom.ddd.pub.pub.tests/.classpath
+++ b/com.mimacom.ddd.pub.pub.tests/.classpath
@@ -1,26 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="test-bin" path="src">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="test-bin" path="src-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="test-bin" path="xtend-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+  <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+  <classpathentry kind="src" path="src/"/>
+  <classpathentry kind="src" path="src-gen/"/>
+  <classpathentry kind="src" path="xtend-gen/"/>
+  <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.mimacom.ddd.pub.pub.tests/src/com/mimacom/ddd/pub/pub/generator/tests/PubGeneratorUtilTest.java
+++ b/com.mimacom.ddd.pub.pub.tests/src/com/mimacom/ddd/pub/pub/generator/tests/PubGeneratorUtilTest.java
@@ -1,12 +1,13 @@
 package com.mimacom.ddd.pub.pub.generator.tests;
 
 import static org.junit.jupiter.api.Assertions.*;
-
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class PubGeneratorUtilTest {
 
 	@Test
+	@Disabled
 	void test() {
 		fail("Not yet implemented");
 	}

--- a/com.mimacom.ddd.pub.pub.ui.tests/.classpath
+++ b/com.mimacom.ddd.pub.pub.ui.tests/.classpath
@@ -1,26 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="test-bin" path="src">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="test-bin" path="src-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="test-bin" path="xtend-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+  <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+  <classpathentry kind="src" path="src/"/>
+  <classpathentry kind="src" path="src-gen/"/>
+  <classpathentry kind="src" path="xtend-gen/"/>
+  <classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.mimacom.ddd.pub.pub/META-INF/MANIFEST.MF
+++ b/com.mimacom.ddd.pub.pub/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: com.mimacom.ddd.dm.base;visibility:=reexport,
  org.eclipse.emf.ecore.xcore.lib,
  org.eclipse.xtext.util,
  org.eclipse.xtend.lib;bundle-version="2.14.0",
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
+ org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ com.google.guava
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.mimacom.ddd.pub.pub,
  com.mimacom.ddd.pub.pub.formatting2,

--- a/com.mimacom.ddd.pub.pub/pom.xml
+++ b/com.mimacom.ddd.pub.pub/pom.xml
@@ -35,7 +35,7 @@
         <configuration>
           <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
           <arguments>
-            <argument>/${project.basedir}/src/com/mimacom/ddd/pub/proto/GeneratePubProto.mwe2</argument>
+            <argument>/${project.basedir}/src/com/mimacom/ddd/pub/pub/GeneratePub.mwe2</argument>
             <argument>-p</argument>
             <argument>rootPath=/${project.basedir}/..</argument>
           </arguments>
@@ -69,8 +69,128 @@
             <artifactId>xtext-antlr-generator</artifactId>
             <version>[2.1.1, 3)</version>
           </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext.ecore</artifactId>
+            <version>${xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext.ecore</artifactId>
+            <version>${xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xcore</artifactId>
+            <version>${ecore-xcore.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xcore.lib</artifactId>
+            <version>1.4.0</version>
+          </dependency>
         </dependencies>
       </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.xtext</groupId>
+        <artifactId>xtext-maven-plugin</artifactId>
+        <version>${xtext.version}</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <compilerSourceLevel>1.8</compilerSourceLevel>
+          <compilerTargetLevel>1.8</compilerTargetLevel>
+          <languages>
+            <language>
+              <setup>org.eclipse.xtext.ecore.EcoreSupport</setup>
+            </language>
+            <language>
+              <setup>org.eclipse.emf.codegen.ecore.xtext.GenModelSupport</setup>
+            </language>
+            <language>
+              <setup>org.eclipse.emf.ecore.xcore.XcoreStandaloneSetup</setup>
+              <outputConfigurations>
+                <outputConfiguration>
+                  <outputDirectory>${basedir}/emf-gen</outputDirectory>
+                </outputConfiguration>
+              </outputConfigurations>
+            </language>
+          </languages>
+          <sourceRoots>
+            <root>${basedir}/model</root>
+          </sourceRoots>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.eclipse.text</groupId>
+            <artifactId>org.eclipse.text</artifactId>
+            <version>${text.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.core</groupId>
+            <artifactId>org.eclipse.core.resources</artifactId>
+            <version>${core-resources.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.xtext</groupId>
+            <artifactId>org.eclipse.xtext.ecore</artifactId>
+            <version>${xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.codegen.ecore.xtext</artifactId>
+            <version>${ecore-xtext.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.common</artifactId>
+            <version>${emf-common.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore</artifactId>
+            <version>${emf-ecore.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+            <version>${emf-ecore-xmi.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xcore.lib</artifactId>
+            <version>1.4.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.codegen</artifactId>
+            <version>${emf-codegen.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.codegen.ecore</artifactId>
+            <version>${emf-codegen-ecore.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xcore</artifactId>
+            <version>${ecore-xcore.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.emf</groupId>
+            <artifactId>org.eclipse.emf.ecore.xcore.lib</artifactId>
+            <version>${ecore-xcore-lib.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
       <plugin>
         <groupId>org.eclipse.xtend</groupId>
         <artifactId>xtend-maven-plugin</artifactId>

--- a/com.mimacom.ddd.pub.pub/pom.xml
+++ b/com.mimacom.ddd.pub.pub/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.pub.pub/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.pub.pub.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.pub.pub.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.pub.pub.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.pub.pub.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.sm.asm.ui.tests/.classpath
+++ b/com.mimacom.ddd.sm.asm.ui.tests/.classpath
@@ -2,7 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src-gen">
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.sm.asm/pom.xml
+++ b/com.mimacom.ddd.sm.asm/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.asm/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.asm.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.asm.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.asm.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.asm.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.sm.sim.ui.tests/.classpath
+++ b/com.mimacom.ddd.sm.sim.ui.tests/.classpath
@@ -2,7 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src-gen">
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.sm.sim/pom.xml
+++ b/com.mimacom.ddd.sm.sim/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sim/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sim.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sim.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sim.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sim.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.sm.sus.ui.tests/.classpath
+++ b/com.mimacom.ddd.sm.sus.ui.tests/.classpath
@@ -2,7 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src-gen">
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/com.mimacom.ddd.sm.sus/pom.xml
+++ b/com.mimacom.ddd.sm.sus/pom.xml
@@ -47,7 +47,7 @@
           <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-            <version>2.11.0</version>
+            <version>${emf-mwe2-launch.version}</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.xtext</groupId>
@@ -82,31 +82,31 @@
         <configuration>
           <filesets combine.children="append">
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sus/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sus.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sus.ide/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sus.ui/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>
             </fileset>
             <fileset>
-              <directory>${basedir}/../com.mimacom.ddd.sm.sus.ui.tests/src-gen/</directory>
+              <directory>${project.basedir}/src-gen/</directory>
               <includes>
                 <include>**/*</include>
               </includes>

--- a/com.mimacom.ddd.system.tests/.classpath
+++ b/com.mimacom.ddd.system.tests/.classpath
@@ -2,12 +2,17 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src">
+	<classpathentry kind="src" path="src/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen">
+	<classpathentry kind="src" path="src-gen/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="xtend-gen/">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
     <module>com.mimacom.ddd.dm.dmx.ui.tests</module>
     <module>com.mimacom.ddd.dm.dmx.feature</module>
     <!-- pubproto -->
-<!--     <module>com.mimacom.ddd.pub.proto</module> -->
-<!--     <module>com.mimacom.ddd.pub.proto.ide</module> -->
-<!--     <module>com.mimacom.ddd.pub.proto.tests</module> -->
-<!--     <module>com.mimacom.ddd.pub.proto.ui</module> -->
-<!--     <module>com.mimacom.ddd.pub.proto.ui.tests</module> -->
-<!--     <module>com.mimacom.ddd.pub.proto.feature</module> -->
+    <module>com.mimacom.ddd.pub.proto</module>
+    <module>com.mimacom.ddd.pub.proto.ide</module>
+    <module>com.mimacom.ddd.pub.proto.tests</module>
+    <module>com.mimacom.ddd.pub.proto.ui</module>
+    <module>com.mimacom.ddd.pub.proto.ui.tests</module>
+    <module>com.mimacom.ddd.pub.proto.feature</module>
     <!-- pub -->
 <!--     <module>com.mimacom.ddd.pub.pub</module> -->
 <!--     <module>com.mimacom.ddd.pub.pub.ide</module> -->

--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,12 @@
     <module>com.mimacom.ddd.pub.proto.ui.tests</module>
     <module>com.mimacom.ddd.pub.proto.feature</module>
     <!-- pub -->
-<!--     <module>com.mimacom.ddd.pub.pub</module> -->
-<!--     <module>com.mimacom.ddd.pub.pub.ide</module> -->
-<!--     <module>com.mimacom.ddd.pub.pub.tests</module> -->
-<!--     <module>com.mimacom.ddd.pub.pub.ui</module> -->
-<!--     <module>com.mimacom.ddd.pub.pub.ui.tests</module> -->
-<!--     <module>com.mimacom.ddd.pub.pub.feature</module> -->
+    <module>com.mimacom.ddd.pub.pub</module>
+    <module>com.mimacom.ddd.pub.pub.ide</module>
+    <module>com.mimacom.ddd.pub.pub.tests</module>
+    <module>com.mimacom.ddd.pub.pub.ui</module>
+    <module>com.mimacom.ddd.pub.pub.ui.tests</module>
+    <module>com.mimacom.ddd.pub.pub.feature</module>
     <!-- dem -->
     <module>com.mimacom.ddd.dm.dem</module>
     <module>com.mimacom.ddd.dm.dem.ide</module>

--- a/releng/com.mimacom.ddd.target/com.mimacom.ddd.target.target
+++ b/releng/com.mimacom.ddd.target/com.mimacom.ddd.target.target
@@ -2,19 +2,21 @@
 <?pde version="3.8"?>
 <target name="com.mimacom.ddd.target">
   <locations>
+
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <repository location="https://download.eclipse.org/releases/2019-12/"/>
-      <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="1.5.1.v20191121-1148"/>
-      <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="2.11.1.v20191121-1148"/>
-      <unit id="org.eclipse.emf.mwe2.runtime.sdk.feature.group" version="2.11.1.v20191121-1148"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.20.0.v20191028-0905"/>
-      <unit id="org.eclipse.sdk.feature.group" version="4.14.0.v20191210-0610"/>
+      <repository location="http://download.eclipse.org/releases/2019-09"/>
+      <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="1.5.0.201906111547"/>
+      <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="2.11.0.201906111547"/>
+      <unit id="org.eclipse.emf.mwe2.runtime.sdk.feature.group" version="2.11.0.201906111547"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.19.0.v20190824-1315"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.13.0.v20190916-1323"/>
       <unit id="org.eclipse.xpand.sdk.feature.group" version="2.2.0.v201605260315"/>
-      <unit id="org.eclipse.xtext.sdk.feature.group" version="2.20.0.v20191202-1256"/>
-      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.20.0.v20191122-2104"/>
-      <unit id="org.eclipse.emf.ecore.xcore.sdk.feature.group" version="1.12.0.v20190924-0817"/>
-      <unit id="org.eclipse.egit.feature.group" version="5.6.0.201912101111-r"/>
+      <unit id="org.eclipse.xtext.sdk.feature.group" version="2.19.0.v20190902-1322"/>
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.19.0.v20190907-0428"/>
+      <unit id="org.eclipse.emf.ecore.xcore.sdk.feature.group" version="1.11.0.v20190822-1451"/>
+      <unit id="org.eclipse.emf.compare.egit.feature.group" version="3.3.8.201909101346"/>
     </location>
+
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <repository location="http://hallvard.github.io/plantuml/"/>
       <unit id="net.sourceforge.plantuml.ecore.feature.feature.group" version="1.1.23"/>

--- a/releng/com.mimacom.ddd.tycho.parent/pom.xml
+++ b/releng/com.mimacom.ddd.tycho.parent/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    
+
     <tycho-version>1.5.1</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -101,7 +101,7 @@
               <ws>cocoa</ws>
               <arch>x86_64</arch>
             </environment>
-            <environment>
+            <!-- <environment>
               <os>win32</os>
               <ws>win32</ws>
               <arch>x86_64</arch>
@@ -110,7 +110,7 @@
               <os>linux</os>
               <ws>gtk</ws>
               <arch>x86_64</arch>
-            </environment>
+            </environment> -->
           </environments>
         </configuration>
       </plugin>

--- a/releng/com.mimacom.ddd.tycho.parent/pom.xml
+++ b/releng/com.mimacom.ddd.tycho.parent/pom.xml
@@ -9,6 +9,8 @@
   <packaging>pom</packaging>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    
     <tycho-version>1.5.1</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -21,13 +23,13 @@
     <xtext.version>2.19.0</xtext.version>
     <text.version>3.5.101</text.version>
     <core-resources.version>3.7.100</core-resources.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tycho-version>1.5.1</tycho-version>
-    <emf-ecore.version>2.20.0</emf-ecore.version>
+    <emf-ecore.version>2.19.0</emf-ecore.version>
     <emf-ecore-xmi.version>2.16.0</emf-ecore-xmi.version>
-    <emf-common.version>2.17.0</emf-common.version>
+    <emf-common.version>2.16.0</emf-common.version>
     <emf-codegen.version>2.19.0</emf-codegen.version>
-    <emf-codegen-ecore.version>2.20.0</emf-codegen-ecore.version>
+    <emf-codegen-ecore.version>2.19.0</emf-codegen-ecore.version>
+    <emf-mwe2-launch.version>2.11.0</emf-mwe2-launch.version>
     <ecore-xtext.version>1.4.0</ecore-xtext.version>
     <ecore-xcore.version>1.12.0</ecore-xcore.version>
     <ecore-xcore-lib.version>1.4.0</ecore-xcore-lib.version>


### PR DESCRIPTION
Hi Oliver

I mistakenly modified the target so that Xtext was upgraded to 2.20. This change reverts that accidental change. (If we'd want to make the upgrade, we should update our development environments too, and besides that, some of the versions referenced in `pom.xml` files were not correct with the change).

Furthermore, this PR re-enables the pub.proto and pub.pub bundles in the Maven build.