### PR TITLE
Fix duplicate synthetic aggregate queries in SIM

### DIFF
--- a/com.mimacom.ddd.sm.sim/src/com/mimacom/ddd/sm/sim/derivedState/SAggregateDeductionRuleProcessor.xtend
+++ b/com.mimacom.ddd.sm.sim/src/com/mimacom/ddd/sm/sim/derivedState/SAggregateDeductionRuleProcessor.xtend
@@ -2,11 +2,9 @@ package com.mimacom.ddd.sm.sim.derivedState
 
 import com.google.inject.Inject
 import com.mimacom.ddd.dm.base.DAggregate
-import com.mimacom.ddd.dm.base.DQuery
 import com.mimacom.ddd.dm.base.IFeatureContainer
 import com.mimacom.ddd.dm.base.ITypeContainer
 import com.mimacom.ddd.sm.sim.SAggregateDeduction
-import com.mimacom.ddd.sm.sim.SFeatureDeduction
 import com.mimacom.ddd.sm.sim.SGrabAggregateRule
 import com.mimacom.ddd.sm.sim.SInformationModel
 import com.mimacom.ddd.sm.sim.SInformationModelKind
@@ -53,13 +51,7 @@ class SAggregateDeductionRuleProcessor {
 				// Process queries grabbed from domain aggregate:
 				if (model.kind == SInformationModelKind.CORE) {
 					val desc = new SyntheticFeatureContainerDescriptor(syntheticAggregate, definition, rule.source as IFeatureContainer)
-					desc.addSyntheticFeatures(context)
-				}
-				
-				// Copy queries added to the rule:
-				var genuineStaticQueries = dAggregate.features.filter [! (it instanceof SFeatureDeduction || it.synthetic)]
-				for (query : genuineStaticQueries) {
-					syntheticAggregate.addSyntheticQueryAsCopy(query as DQuery, context)
+					desc.addSyntheticFeatures(context) // = queries
 				}
 			}
 		}

--- a/com.mimacom.ddd.sm.sim/src/com/mimacom/ddd/sm/sim/derivedState/SimDerivedStateComputer.xtend
+++ b/com.mimacom.ddd.sm.sim/src/com/mimacom/ddd/sm/sim/derivedState/SimDerivedStateComputer.xtend
@@ -57,7 +57,7 @@ class SimDerivedStateComputer implements IDerivedStateComputer {
 	def void processInformationModel(SInformationModel model, TransformationContext context) {
 		// First: process the types defined by the model:
 		val typeDeductionDefinitions = model.types.filter(STypeDeduction)?.toList // cannot sort iterable 
-		if (typeDeductionDefinitions !== null) {
+		if (! typeDeductionDefinitions.empty) {
 			Collections.sort(typeDeductionDefinitions, new TypeSorter)
 			val complexSyntheticTypes = Lists.newArrayList
 			for (definition : typeDeductionDefinitions) {

--- a/com.mimacom.ddd.sm.sim/xtend-gen/com/mimacom/ddd/sm/sim/derivedState/SAggregateDeductionRuleProcessor.java
+++ b/com.mimacom.ddd.sm.sim/xtend-gen/com/mimacom/ddd/sm/sim/derivedState/SAggregateDeductionRuleProcessor.java
@@ -4,13 +4,10 @@ import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.mimacom.ddd.dm.base.DAggregate;
 import com.mimacom.ddd.dm.base.DDeductionRule;
-import com.mimacom.ddd.dm.base.DFeature;
-import com.mimacom.ddd.dm.base.DQuery;
 import com.mimacom.ddd.dm.base.IDeducibleElement;
 import com.mimacom.ddd.dm.base.IFeatureContainer;
 import com.mimacom.ddd.dm.base.ITypeContainer;
 import com.mimacom.ddd.sm.sim.SAggregateDeduction;
-import com.mimacom.ddd.sm.sim.SFeatureDeduction;
 import com.mimacom.ddd.sm.sim.SGrabAggregateRule;
 import com.mimacom.ddd.sm.sim.SInformationModel;
 import com.mimacom.ddd.sm.sim.SInformationModelKind;
@@ -94,13 +91,6 @@ public class SAggregateDeductionRuleProcessor {
           IDeducibleElement _source = rule.getSource();
           final SyntheticFeatureContainerDescriptor desc = new SyntheticFeatureContainerDescriptor(syntheticAggregate, definition, ((IFeatureContainer) _source));
           this._sFeatureDeductionRuleProcessor.addSyntheticFeatures(desc, context);
-        }
-        final Function1<DFeature, Boolean> _function_1 = (DFeature it) -> {
-          return Boolean.valueOf((!((it instanceof SFeatureDeduction) || it.isSynthetic())));
-        };
-        Iterable<DFeature> genuineStaticQueries = IterableExtensions.<DFeature>filter(((SAggregateDeduction)dAggregate).getFeatures(), _function_1);
-        for (final DFeature query : genuineStaticQueries) {
-          this._syntheticModelElementsFactory.addSyntheticQueryAsCopy(syntheticAggregate, ((DQuery) query), context);
         }
       }
     }

--- a/com.mimacom.ddd.sm.sim/xtend-gen/com/mimacom/ddd/sm/sim/derivedState/SimDerivedStateComputer.java
+++ b/com.mimacom.ddd.sm.sim/xtend-gen/com/mimacom/ddd/sm/sim/derivedState/SimDerivedStateComputer.java
@@ -97,7 +97,9 @@ public class SimDerivedStateComputer implements IDerivedStateComputer {
       _list=IterableExtensions.<STypeDeduction>toList(_filter);
     }
     final List<STypeDeduction> typeDeductionDefinitions = _list;
-    if ((typeDeductionDefinitions != null)) {
+    boolean _isEmpty = typeDeductionDefinitions.isEmpty();
+    boolean _not = (!_isEmpty);
+    if (_not) {
       TypeSorter _typeSorter = new TypeSorter();
       Collections.<STypeDeduction>sort(typeDeductionDefinitions, _typeSorter);
       final ArrayList<SyntheticFeatureContainerDescriptor> complexSyntheticTypes = Lists.<SyntheticFeatureContainerDescriptor>newArrayList();


### PR DESCRIPTION
Hi Johan
I fixed the issue that queries added to a SIM 'grab aggregate' rule were added to the deducted
synthetic aggregate twice.