### PR TITLE
fix class cast exception in diagram provider

### DIFF
--- a/com.mimacom.ddd.dm.dem.ui/src/com/mimacom/ddd/dm/dem/ui/plantuml/DemDiagramTextProvider.xtend
+++ b/com.mimacom.ddd.dm.dem.ui/src/com/mimacom/ddd/dm/dem/ui/plantuml/DemDiagramTextProvider.xtend
@@ -31,7 +31,7 @@ class DemDiagramTextProvider extends AbstractDiagramTextProvider {
         val namespace = document.readOnly[
             return if (contents.head instanceof DNamespace) contents.head as DNamespace else null
         ]
-        val event = namespace.model as DemDomainEvent
+        val event = namespace.model instanceof DemDomainEvent ? namespace.model as DemDomainEvent : null
         
         if (event === null) {
         	return '''note "No domain event to show." as N1'''

--- a/com.mimacom.ddd.dm.dem.ui/xtend-gen/com/mimacom/ddd/dm/dem/ui/plantuml/DemDiagramTextProvider.java
+++ b/com.mimacom.ddd.dm.dem.ui/xtend-gen/com/mimacom/ddd/dm/dem/ui/plantuml/DemDiagramTextProvider.java
@@ -54,8 +54,15 @@ public class DemDiagramTextProvider extends AbstractDiagramTextProvider {
       return _xifexpression;
     };
     final DNamespace namespace = document.<DNamespace>readOnly(_function);
+    DemDomainEvent _xifexpression = null;
     DModel _model = namespace.getModel();
-    final DemDomainEvent event = ((DemDomainEvent) _model);
+    if ((_model instanceof DemDomainEvent)) {
+      DModel _model_1 = namespace.getModel();
+      _xifexpression = ((DemDomainEvent) _model_1);
+    } else {
+      _xifexpression = null;
+    }
+    final DemDomainEvent event = _xifexpression;
     if ((event == null)) {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("note \"No domain event to show.\" as N1");

--- a/com.mimacom.ddd.sm.sim.ui/src/com/mimacom/ddd/sm/sim/ui/plantuml/SimDiagramTextProvider.xtend
+++ b/com.mimacom.ddd.sm.sim.ui/src/com/mimacom/ddd/sm/sim/ui/plantuml/SimDiagramTextProvider.xtend
@@ -36,9 +36,11 @@ class SimDiagramTextProvider extends AbstractDiagramTextProvider {
             return if (contents.head instanceof DNamespace) contents.head as DNamespace else null
         ]
         
-        val model = namespace.model as SInformationModel
-        if (actualProvider.canProvide(model)) {
-        	return actualProvider.diagramText(model)
+        if (namespace !== null) {        	
+	        val model = namespace.model as SInformationModel
+	        if (actualProvider.canProvide(model)) {
+	        	return actualProvider.diagramText(model)
+        	}
         }
         return '''note "No structures to show." as N1'''
 	}

--- a/com.mimacom.ddd.sm.sim.ui/xtend-gen/com/mimacom/ddd/sm/sim/ui/plantuml/SimDiagramTextProvider.java
+++ b/com.mimacom.ddd.sm.sim.ui/xtend-gen/com/mimacom/ddd/sm/sim/ui/plantuml/SimDiagramTextProvider.java
@@ -55,11 +55,13 @@ public class SimDiagramTextProvider extends AbstractDiagramTextProvider {
       return _xifexpression;
     };
     final DNamespace namespace = document.<DNamespace>readOnly(_function);
-    DModel _model = namespace.getModel();
-    final SInformationModel model = ((SInformationModel) _model);
-    boolean _canProvide = this.actualProvider.canProvide(model);
-    if (_canProvide) {
-      return this.actualProvider.diagramText(model);
+    if ((namespace != null)) {
+      DModel _model = namespace.getModel();
+      final SInformationModel model = ((SInformationModel) _model);
+      boolean _canProvide = this.actualProvider.canProvide(model);
+      if (_canProvide) {
+        return this.actualProvider.diagramText(model);
+      }
     }
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("note \"No structures to show.\" as N1");


### PR DESCRIPTION
Do not take for granted that the namespace model is a `DemDomainEvent`,
it may also be a `DemActorModel` for instance.

Fixes an error which may reproduced as follows:
1. open `actors.dem` of the examples project
2. find error log entry in the Error Log

![image](https://user-images.githubusercontent.com/1107810/74313048-3ab8f880-4d73-11ea-93ff-affa52e96612.png)
